### PR TITLE
Added NSCache, README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,23 @@
-```ruby
-pod 'UIImage+ImageWithColor'
-```
+#UIImage+ImageWithColor
+
+[![Version](https://img.shields.io/cocoapods/v/UIImage+ImageWithColor.svg?style=flat)](http://cocoadocs.org/docsets/UIImage+ImageWithColor)
+[![License](https://img.shields.io/cocoapods/l/UIImage+ImageWithColor.svg?style=flat)](http://cocoadocs.org/docsets/UIImage+ImageWithColor)
+[![Platform](https://img.shields.io/cocoapods/p/UIImage+ImageWithColor.svg?style=flat)](http://cocoadocs.org/docsets/UIImage+ImageWithColor)
+
+**Create (optionally resizable & rounded) plain-colored `UIImages`..**
+
+####CocoaPods
+
+[CocoaPods](http://cocoapods.org/) is the recommended way to use UIImage+ImageWithColor in your project.
+
+* Simply add this line to your `Podfile`: `pod 'UIImage+ImageWithColor'`
+* Run `pod install`.
+
+####Manual installation
+
+* Add `UIImage+ImageWithColor` header and implementation to your project (2 files total).
+
+###How To Use It
 
 ```objc
 #import "UIImage+ImageWithColor.h"
@@ -21,3 +38,11 @@ UIColor *color = [UIColor purpleColor];
 UIImage *img = [UIImage resizableImageWithColor:color cornerRadius:10];
 [self.button setBackgroundImage:img forControlState:UIControlStateNormal];
 ```
+
+###Author
+
+Created and maintained by Max Howell ([@Max Howell](https://twitter.com/mxcl)).
+
+###License
+
+This is free and unencumbered software released into the public domain.

--- a/UIImage+ImageWithColor.m
+++ b/UIImage+ImageWithColor.m
@@ -2,21 +2,37 @@
 
 #import "UIImage+ImageWithColor.h"
 
+static NSCache *imageCache;
 
 @implementation UIImage (WithColor)
 
 + (UIImage *)imageWithColor:(UIColor *)color {
-    return [self imageWithColor:color size:CGSizeMake(1,1)];
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        imageCache = [[NSCache alloc] init];
+    });
+    
+    UIImage *image = [imageCache objectForKey:color];
+    if (image) {
+        return image;
+    }
+    
+    image = [self imageWithColor:color size:CGSizeMake(1,1)];
+    [imageCache setObject:image forKey:color];
+    
+    return image;
 }
 
 + (UIImage *)imageWithColor:(UIColor *)color size:(CGSize)size {
-	CGRect rect = CGRectMake(0, 0, size.width, size.height);
+    CGRect rect = CGRectMake(0, 0, size.width, size.height);
     UIGraphicsBeginImageContext(rect.size);
     CGContextRef context = UIGraphicsGetCurrentContext();
     CGContextSetFillColorWithColor(context, [color CGColor]);
     CGContextFillRect(context, rect);
+    
     UIImage *img = UIGraphicsGetImageFromCurrentImageContext();
     UIGraphicsEndImageContext();
+    
     return img;
 }
 
@@ -25,6 +41,7 @@
     CGRect rect = CGRectMake(0, 0, minEdgeSize, minEdgeSize);
     UIBezierPath *roundedRect = [UIBezierPath bezierPathWithRoundedRect:rect cornerRadius:cornerRadius];
     roundedRect.lineWidth = 0;
+    
     UIGraphicsBeginImageContextWithOptions(rect.size, NO, 0.0f);
     [color setFill];
     [roundedRect fill];
@@ -32,6 +49,7 @@
     [roundedRect addClip];
     UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
     UIGraphicsEndImageContext();
+    
     return [image resizableImageWithCapInsets:UIEdgeInsetsMake(cornerRadius, cornerRadius, cornerRadius, cornerRadius)];
 }
 

--- a/UNLICENSE
+++ b/UNLICENSE
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <http://unlicense.org>


### PR DESCRIPTION
First of all, proposing this changes as this is most completed, unencumbered and clear version of common category to use in many project.

It is really handy for me to add 1 line into `Podfile` than search for this on Stackoverflow and copy-paste over and over. Thanks for creating and sharing it.

The main changes I am proposing:
* using `NSCache` for storing cache of 1x1 `UIImages` (originally seen at [Artsy's Eigen](https://github.com/artsy/eigen/blob/master/Artsy/Classes/Categories/Apple/UIImage%2BImageFromColor.m))
* formatting README and adding UNLICENSE
